### PR TITLE
Fix a bug of app not closing on Windows/Linux

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -43,6 +43,7 @@ function createWindow() {
 
 app.on('window-all-closed', () => {
   win = null
+  if (process.platform !== 'darwin') app.quit()
 })
 
 app.whenReady().then(createWindow)


### PR DESCRIPTION
Add `app.quit()` for Windows and Linux to ensure the app quits when all windows are closed.